### PR TITLE
unreasonable effectiveness: rust_std_stable -> rust_std_unstable

### DIFF
--- a/writeup/unreasonable/text.md
+++ b/writeup/unreasonable/text.md
@@ -376,12 +376,12 @@ library function is `slice::sort_unstable`.
 
 <img src="assets/scaling-d4-comp.webp" width=960 />
 
-For L3 sized inputs rust_std_stable can do ~660 million elements per second,
+For L3 sized inputs rust_std_unstable can do ~660 million elements per second,
 implying the CPU spends ~7.4 cycles per element. It does so without knowing
 anything about the input before processing it and is only able to establish a
 less than relationship between two elements.
 
-Since rust_std_stable does more memory accesses than the hash map approach it is
+Since rust_std_unstable does more memory accesses than the hash map approach it is
 affected more intensely by the increased latency of DRAM.
 
 ### Various generic algorithms
@@ -402,7 +402,7 @@ The details about what versions are being tested are found
 Phf, branchless and match bucket sorting results are omitted from this graph to
 limit visual overload and range compression.
 
-For L3 sized inputs rust_std_stable can do ~660 million elements per second,
+For L3 sized inputs rust_std_unstable can do ~660 million elements per second,
 implying the CPU spends ~7.4 cycles per element. It does so without knowing
 anything about the input before processing it and only being able to establish a
 less than relationship between two elements.


### PR DESCRIPTION
Replace some occurences of rust_std_stable that seem odd to me with *_unstable, as they don't seem to fit; The first ones are in a paragraph/under a graph about unstable, and thr second ones are the exact same paragraph as the first.